### PR TITLE
Downgrade test projects from DotNetCore 2.2 => 2.1

### DIFF
--- a/csharp/Helloworld/Greeter.sln
+++ b/csharp/Helloworld/Greeter.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.4
@@ -9,41 +8,44 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreeterClient", "GreeterCli
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreeterServer", "GreeterServer\GreeterServer.csproj", "{DDBFF994-E076-43AD-B18D-049DFC1B670C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreeterClient.Tests", "GreeterClient.Tests\GreeterClient.Tests.csproj", "{A2A41580-6223-48FB-8195-FC7131119F54}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreeterClient.Tests", "GreeterClient.Tests\GreeterClient.Tests.csproj", "{A2A41580-6223-48FB-8195-FC7131119F54}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreeterServer.Tests", "GreeterServer.Tests\GreeterServer.Tests.csproj", "{00062D3F-2F87-4427-B2B1-DC615190AAF0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreeterServer.Tests", "GreeterServer.Tests\GreeterServer.Tests.csproj", "{00062D3F-2F87-4427-B2B1-DC615190AAF0}"
 EndProject
 Global
-  GlobalSection(SolutionConfigurationPlatforms) = preSolution
-    Debug|Any CPU = Debug|Any CPU
-    Release|Any CPU = Release|Any CPU
-  EndGlobalSection
-  GlobalSection(ProjectConfigurationPlatforms) = postSolution
-    {13B6DFC8-F5F6-4CC2-99DF-57A7CF042033}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {13B6DFC8-F5F6-4CC2-99DF-57A7CF042033}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {13B6DFC8-F5F6-4CC2-99DF-57A7CF042033}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {13B6DFC8-F5F6-4CC2-99DF-57A7CF042033}.Release|Any CPU.Build.0 = Release|Any CPU
-    {B754FB02-D501-4308-8B89-33AB7119C80D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {B754FB02-D501-4308-8B89-33AB7119C80D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {B754FB02-D501-4308-8B89-33AB7119C80D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {B754FB02-D501-4308-8B89-33AB7119C80D}.Release|Any CPU.Build.0 = Release|Any CPU
-    {DDBFF994-E076-43AD-B18D-049DFC1B670C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {DDBFF994-E076-43AD-B18D-049DFC1B670C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {DDBFF994-E076-43AD-B18D-049DFC1B670C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {DDBFF994-E076-43AD-B18D-049DFC1B670C}.Release|Any CPU.Build.0 = Release|Any CPU
-    {A2A41580-6223-48FB-8195-FC7131119F54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {A2A41580-6223-48FB-8195-FC7131119F54}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {A2A41580-6223-48FB-8195-FC7131119F54}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {A2A41580-6223-48FB-8195-FC7131119F54}.Release|Any CPU.Build.0 = Release|Any CPU
-    {00062D3F-2F87-4427-B2B1-DC615190AAF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {00062D3F-2F87-4427-B2B1-DC615190AAF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {00062D3F-2F87-4427-B2B1-DC615190AAF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {00062D3F-2F87-4427-B2B1-DC615190AAF0}.Release|Any CPU.Build.0 = Release|Any CPU
-  EndGlobalSection
-  GlobalSection(SolutionProperties) = preSolution
-    HideSolutionNode = FALSE
-  EndGlobalSection
-  GlobalSection(MonoDevelopProperties) = preSolution
-    outputpath = ../../build/bin
-  EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{13B6DFC8-F5F6-4CC2-99DF-57A7CF042033}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13B6DFC8-F5F6-4CC2-99DF-57A7CF042033}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13B6DFC8-F5F6-4CC2-99DF-57A7CF042033}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13B6DFC8-F5F6-4CC2-99DF-57A7CF042033}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B754FB02-D501-4308-8B89-33AB7119C80D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B754FB02-D501-4308-8B89-33AB7119C80D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B754FB02-D501-4308-8B89-33AB7119C80D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B754FB02-D501-4308-8B89-33AB7119C80D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDBFF994-E076-43AD-B18D-049DFC1B670C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDBFF994-E076-43AD-B18D-049DFC1B670C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDBFF994-E076-43AD-B18D-049DFC1B670C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDBFF994-E076-43AD-B18D-049DFC1B670C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2A41580-6223-48FB-8195-FC7131119F54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2A41580-6223-48FB-8195-FC7131119F54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2A41580-6223-48FB-8195-FC7131119F54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2A41580-6223-48FB-8195-FC7131119F54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00062D3F-2F87-4427-B2B1-DC615190AAF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00062D3F-2F87-4427-B2B1-DC615190AAF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00062D3F-2F87-4427-B2B1-DC615190AAF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00062D3F-2F87-4427-B2B1-DC615190AAF0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C993599D-315B-49A3-A68C-77A9383845AA}
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		    outputpath = ../../build/bin
+	EndGlobalSection
 EndGlobal

--- a/csharp/Helloworld/GreeterClient.Tests/GreeterClient.Tests.csproj
+++ b/csharp/Helloworld/GreeterClient.Tests/GreeterClient.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/csharp/Helloworld/GreeterServer.Tests/GreeterServer.Tests.csproj
+++ b/csharp/Helloworld/GreeterServer.Tests/GreeterServer.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Using the Windows based Visual Studio, I was getting compile errors. The base source projects were targeting DotNetCore 2.1 while the test projects were targeting DotNetCore 2.2. This fixes that build error.